### PR TITLE
SOLID - Dependency Inversion applied

### DIFF
--- a/csharp/SOLID Design Principles/5-DependencyInversion/Api.Tests/Api.Tests.csproj
+++ b/csharp/SOLID Design Principles/5-DependencyInversion/Api.Tests/Api.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/csharp/SOLID Design Principles/5-DependencyInversion/Api.Tests/StudentTest.cs
+++ b/csharp/SOLID Design Principles/5-DependencyInversion/Api.Tests/StudentTest.cs
@@ -6,38 +6,27 @@ using DependencyInversion;
 namespace Api.Tests;
 
 
-public class StudentTest 
+public class StudentTest
 {
+
     [Fact]
     public void GetStudent()
     {
-        var studentController = new StudentController();
+        var logbookMock = new Mock<ILog>();
+        var stundentRepositoryMock = new Mock<IRepository>();
+        stundentRepositoryMock.Setup(p => p.GetAll())
+                                        .Returns(
+                                        [
+                                             new Student(1, "Pepito Pérez", new List<double>() { 3, 4.5 }),
+                                             new Student(2, "Mariana Lopera", new List<double>() { 4, 5 }),
+                                             new Student(3, "José Molina", new List<double>() { 2, 3 })
+                                        ]);
+
+        var studentController = new StudentController(stundentRepositoryMock.Object, logbookMock.Object);
 
         var resultGetStudents = studentController.Get();
 
         Assert.NotNull(resultGetStudents);
         Assert.Equal(3, resultGetStudents.Count());
     }
-
-
-    //[Fact]
-    //public void GetStudent()
-    //{
-    //    var LogbookMock = new Mock<ILogbook>();
-    //    var stundentRepositoryMock = new Mock<IStudentRepository>();
-    //    stundentRepositoryMock.Setup(p => p.GetAll())
-    //                                    .Returns(new List<Student>()
-    //                                    {
-    //                                         new Student(1, "Pepito Pérez", new List<double>() { 3, 4.5 }),
-    //                                         new Student(2, "Mariana Lopera", new List<double>() { 4, 5 }),
-    //                                         new Student(3, "José Molina", new List<double>() { 2, 3 })
-    //                                    });
-
-    //    var studentController = new StudentController();
-
-    //    var resultGetStudents = studentController.Get();
-
-    //    Assert.NotNull(resultGetStudents);
-    //    Assert.Equal(3, resultGetStudents.Count());
-    //}
 }

--- a/csharp/SOLID Design Principles/5-DependencyInversion/Api/Api.csproj
+++ b/csharp/SOLID Design Principles/5-DependencyInversion/Api/Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/csharp/SOLID Design Principles/5-DependencyInversion/Api/Controllers/StudentController.cs
+++ b/csharp/SOLID Design Principles/5-DependencyInversion/Api/Controllers/StudentController.cs
@@ -5,20 +5,26 @@ namespace DependencyInversion.Controllers;
 [ApiController, Route("student")]
 public class StudentController : ControllerBase
 {
-    StudentRepository studentRepository = new StudentRepository();
-    Logbook logbook = new Logbook();
+    private readonly IRepository _studentRepository;
+    private readonly ILog _logbook;
+
+    public StudentController(IRepository repository, ILog log)
+    {
+        _studentRepository = repository;
+        _logbook = log;
+    }
 
     [HttpGet]
     public IEnumerable<Student> Get()
     {
-        logbook.Add($"returning student's list");
-        return studentRepository.GetAll();
+        _logbook.Add($"returning student's list");
+        return _studentRepository.GetAll();
     }
 
     [HttpPost]
     public void Add([FromBody]Student student)
     {
-        studentRepository.Add(student);
-        logbook.Add($"The Student {student.Fullname} have been added");
+        _studentRepository.Add(student);
+        _logbook.Add($"The Student {student.Fullname} have been added");
     }
 }

--- a/csharp/SOLID Design Principles/5-DependencyInversion/Api/Models/Logbook.cs
+++ b/csharp/SOLID Design Principles/5-DependencyInversion/Api/Models/Logbook.cs
@@ -2,11 +2,16 @@ using System.Text;
 
 namespace DependencyInversion
 {
-    public class Logbook
+    public class Logbook : ILog
     {
         public void Add(string description)
         {
             File.AppendAllText(System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "logbook.txt"), $"{description}\n", Encoding.Unicode);
         }
+    }
+
+    public interface ILog
+    {
+        public void Add(string description);
     }
 }

--- a/csharp/SOLID Design Principles/5-DependencyInversion/Api/Program.cs
+++ b/csharp/SOLID Design Principles/5-DependencyInversion/Api/Program.cs
@@ -1,10 +1,17 @@
-﻿using DependencyInversion;
+using System.Collections.ObjectModel;
+using DependencyInversion;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddRazorPages();
-builder.Services.AddSingleton<IRepository, StudentRepository>();
+// Init Student Repository data
+ObservableCollection<Student> initData = [];
+initData.Add(new Student(1, "Pepito Pérez", [3, 4.5]));
+initData.Add(new Student(2, "Mariana Lopera", [4, 5]));
+initData.Add(new Student(3, "José Molina", [2, 3]));
+builder.Services.AddSingleton<IRepository>(
+    repo => new StudentRepository(initData));
 builder.Services.AddSingleton<ILog, Logbook>();
 
 builder.Services.AddControllers();

--- a/csharp/SOLID Design Principles/5-DependencyInversion/Api/Program.cs
+++ b/csharp/SOLID Design Principles/5-DependencyInversion/Api/Program.cs
@@ -1,6 +1,11 @@
-﻿var builder = WebApplication.CreateBuilder(args);
+﻿using DependencyInversion;
+
+var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+builder.Services.AddRazorPages();
+builder.Services.AddSingleton<IRepository, StudentRepository>();
+builder.Services.AddSingleton<ILog, Logbook>();
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/csharp/SOLID Design Principles/5-DependencyInversion/Api/Repository/StudentRepository.cs
+++ b/csharp/SOLID Design Principles/5-DependencyInversion/Api/Repository/StudentRepository.cs
@@ -2,34 +2,18 @@ using System.Collections.ObjectModel;
 
 namespace DependencyInversion
 {
-    public class StudentRepository : IRepository
+    public class StudentRepository(ObservableCollection<Student>? initData = null) : IRepository
     {
-        private static ObservableCollection<Student> collection;
-
-        public StudentRepository()
-        {
-            InitData();
-        }
-
-        private void InitData()
-        {
-            if (collection == null)
-            {
-                collection = new();
-                collection.Add(new Student(1, "Pepito Pérez", new List<double>() { 3, 4.5 }));
-                collection.Add(new Student(2, "Mariana Lopera", new List<double>() { 4, 5 }));
-                collection.Add(new Student(3, "José Molina", new List<double>() { 2, 3 }));
-            }
-        }
+        private readonly ObservableCollection<Student> storage = initData ?? [];
 
         public IEnumerable<Student> GetAll()
         {
-            return collection;
+            return storage;
         }
 
         public void Add(Student student)
         {
-            collection.Add(student);
+            storage.Add(student);
         }
     }
 

--- a/csharp/SOLID Design Principles/5-DependencyInversion/Api/Repository/StudentRepository.cs
+++ b/csharp/SOLID Design Principles/5-DependencyInversion/Api/Repository/StudentRepository.cs
@@ -2,7 +2,7 @@ using System.Collections.ObjectModel;
 
 namespace DependencyInversion
 {
-    public class StudentRepository
+    public class StudentRepository : IRepository
     {
         private static ObservableCollection<Student> collection;
 
@@ -13,7 +13,7 @@ namespace DependencyInversion
 
         private void InitData()
         {
-            if (collection == null) 
+            if (collection == null)
             {
                 collection = new();
                 collection.Add(new Student(1, "Pepito Pérez", new List<double>() { 3, 4.5 }));
@@ -31,5 +31,11 @@ namespace DependencyInversion
         {
             collection.Add(student);
         }
+    }
+
+    public interface IRepository
+    {
+        public IEnumerable<Student> GetAll();
+        public void Add(Student student);
     }
 }


### PR DESCRIPTION
In this exercise I changed the instantiation of required concrete classes references in the controller by using the ASP.NET Core Blazor dependency injection; for that I created necessary interfaces to use high-level references and concrete services instances registration as singletones in the contex. 